### PR TITLE
closes JustGiving/JustGiving.EventStore.Http#17

### DIFF
--- a/src/JustGiving.EventStore.Http.Client.Tests/EventStoreHttpConnectionTests.cs
+++ b/src/JustGiving.EventStore.Http.Client.Tests/EventStoreHttpConnectionTests.cs
@@ -28,14 +28,14 @@ namespace JustGiving.EventStore.Http.Client.Tests
         {
             _httpClientProxyMock = new Mock<IHttpClientProxy>();
             _defaultConnectionSettings = GetConnectionSettings();
-            _connection = (EventStoreHttpConnection)EventStoreHttpConnection.Create(_defaultConnectionSettings, Endpoint);
+            _connection = EventStoreHttpConnection.Create(_defaultConnectionSettings, Endpoint);
         }
 
         [Test]
         public void GetHandler_WhenNoDefaultCredentialsAreConfigured_TheClientShouldNotHaveAnyCredentials()
         {
-            var builder = new ConnectionSettingsBuilder().WithHttpClientProxy(_httpClientProxyMock.Object);
-            _connection = (EventStoreHttpConnection)EventStoreHttpConnection.Create(builder, Endpoint);
+            var settings = new ConnectionSettingsBuilder().WithHttpClientProxy(_httpClientProxyMock.Object);
+            _connection = EventStoreHttpConnection.Create(settings, Endpoint);
 
             var handler = _connection.GetHandler();
             handler.Credentials.Should().BeNull();
@@ -54,7 +54,7 @@ namespace JustGiving.EventStore.Http.Client.Tests
         [Test]
         public void GetClient_WhenNoDefaultTimeoutIsConfigured_TheClientShouldBe100Seconds()
         {
-            _connection = (EventStoreHttpConnection)EventStoreHttpConnection.Create(ConnectionSettings.Default, Endpoint);
+            _connection = EventStoreHttpConnection.Create(ConnectionSettings.Default, Endpoint);
 
             var client = _connection.GetClient();
             client.Timeout.Should().Be(TimeSpan.FromSeconds(100));

--- a/src/JustGiving.EventStore.Http.Client/EventStoreHttpConnection.cs
+++ b/src/JustGiving.EventStore.Http.Client/EventStoreHttpConnection.cs
@@ -15,8 +15,12 @@ namespace JustGiving.EventStore.Http.Client
 {
     /// <summary>
     /// EventStore Http connection.
+    /// <para>
+    /// As this connection is backed by <see cref="HttpClient"/>, clients are subject to connection management per <see cref="ServicePointManager"/>.
+    /// See https://msdn.microsoft.com/en-us/library/system.net.servicepoint%28v=vs.110%29.aspx for details on configuration options.
+    /// </para>
     /// </summary>
-    /// <remarks>Clients should dispose of this <see cref="EventStoreHttpConnection"/> to release any resources it may have in use.</remarks>
+    /// <remarks>Clients of instances of this type should dispose of it, to release any resources it may have in use.</remarks>
     public class EventStoreHttpConnection : IEventStoreHttpConnection, IDisposable
     {
         private readonly ConnectionSettings _settings;


### PR DESCRIPTION
Re-use HttpClient and HttpClientHandler for requests dispatched by EventStoreHttpConnection to be more efficient in resource usage.
Also, dispose of HttpRequestMessages while we're there.